### PR TITLE
:white_check_mark: Add support for python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.9

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.8.0
-envlist = python3.8, python3.9, python3.10, python3.11, flake8, mypy
+envlist = python3.8, python3.9, python3.10, python3.11, python3.12, flake8, mypy
 isolated_build = true
 
 [gh-actions]
@@ -9,6 +9,7 @@ python =
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
+    3.12: python3.12
 
 [testenv]
 setenv =


### PR DESCRIPTION
Adds support for python 3.12, can be merged as soon as aiohttp fixes [this issue](https://github.com/aio-libs/aiohttp/issues/7739).